### PR TITLE
Fix test to be resilient against different method ordering

### DIFF
--- a/src/test/java/guiceutils/childinjectortools/destroyable/DestroyableComponentLifecycleManagerTest.java
+++ b/src/test/java/guiceutils/childinjectortools/destroyable/DestroyableComponentLifecycleManagerTest.java
@@ -31,13 +31,19 @@ public class DestroyableComponentLifecycleManagerTest {
 	@Mock InvocationTargetException methodInvokationException;
 	
 	ClassWithAnnotatedPreDestroy preDestroyClass = new ClassWithAnnotatedPreDestroy();
-	Method method = preDestroyClass.getClass().getDeclaredMethods()[0];
-	Method exceptionMethod = preDestroyClass.getClass().getDeclaredMethods()[1];
+	Method method;
+	Method exceptionMethod;
 	
 	List<Object> singletonList;
 	
 	DestroyableComponentLifecycleManager manager;
-	
+
+    @Before
+    public void find_test_methods() throws NoSuchMethodException {
+        method = preDestroyClass.getClass().getDeclaredMethod("destroy");
+        exceptionMethod = preDestroyClass.getClass().getDeclaredMethod("throwError");
+    }
+
 	@Before 
 	public void initialise_singleton_list() {
 		singletonList = new ArrayList<Object>();


### PR DESCRIPTION
The test was previously assuming that they would be found in source order -- that isn't necessarily the
case. So look them up by name instead.
